### PR TITLE
Issue 8 - Chat message - missing ToolCallID

### DIFF
--- a/types.go
+++ b/types.go
@@ -5,10 +5,10 @@ const (
 	ModelMistralMediumLatest = "mistral-medium-latest"
 	ModelMistralSmallLatest  = "mistral-small-latest"
 	ModelCodestralLatest     = "codestral-latest"
-	
-	ModelOpenMixtral8x7b     = "open-mixtral-8x7b"
-	ModelOpenMixtral8x22b    = "open-mixtral-8x22b"
-	ModelOpenMistral7b       = "open-mistral-7b"
+
+	ModelOpenMixtral8x7b  = "open-mixtral-8x7b"
+	ModelOpenMixtral8x22b = "open-mixtral-8x22b"
+	ModelOpenMistral7b    = "open-mistral-7b"
 
 	ModelMistralLarge2402  = "mistral-large-2402"
 	ModelMistralMedium2312 = "mistral-medium-2312"
@@ -89,7 +89,8 @@ type DeltaMessage struct {
 
 // ChatMessage represents a single message in a chat.
 type ChatMessage struct {
-	Role      string     `json:"role"`
-	Content   string     `json:"content"`
-	ToolCalls []ToolCall `json:"tool_calls,omitempty"`
+	Role       string     `json:"role"`
+	Content    string     `json:"content"`
+	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`
+	ToolCallID string     `json:"tool_call_id,omitempty"`
 }


### PR DESCRIPTION
[Issue 8 - Chat message - missing ToolCallID](https://github.com/Gage-Technologies/mistral-go/issues/8)

When executing function to obtain tool results. Mistral need TooCallID.

Adding ToolCallID to ChatMessage structure
  ToolCallID string     `json:"tool_call_id,omitempty"`